### PR TITLE
fix(naming): Fix up some places that were still referring to fake_http

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: There is a problem in how fake_http behaves
+about: There is a problem in how charlatan behaves
 title: ""
 labels: bug
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for fake_http
+about: Suggest an idea for charlatan
 title: ""
 labels: enhancement
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # charlatan
 
 [![pub package](https://img.shields.io/pub/v/charlatan.svg)](https://pub.dev/packages/charlatan)
-[![Build status](https://github.com/Betterment/dart_fake_http/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Betterment/charlatan/actions/workflows/ci.yml?query=branch%3Amain)
+[![Build status](https://github.com/Betterment/charlatan/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Betterment/charlatan/actions/workflows/ci.yml?query=branch%3Amain)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/Betterment/charlatan/pulse)
 


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->

Just patching up a few places that were still referring to `fake_http` 🦅  👀 

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->

None!

### Reviewers
<!-- This is used by us to signal to the correct people that your PR needs review -->
/domain @Betterment/charlatan-maintainers
/platform @Betterment/charlatan-maintainers
