### PR TITLE
chore: upgrade dio to 5.0.0

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,0 @@
-titleOnly: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.3.5
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v3.3.0
+      - uses: dart-lang/setup-dart@v1.4
 
       - name: Install dependencies
         run: dart pub get
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.3.5
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v3.3.0
+      - uses: dart-lang/setup-dart@v1.4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,26 @@
+name: Semantic PR
+
+on: [pull_request]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v4.6.0
+        with:
+          types:
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            ci
+            chore
+          validateSingleCommit: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Upgrade `dio` to `5.0.0`
+
 ## 0.1.0
 
 - Upgrade `dio` and `test`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  dio: ^4.0.4
+  dio: ^5.0.0
   meta: ^1.7.0
   uri: ^1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: charlatan
 description: A library for configuring and providing fake HTTP responses to your dio HTTP client.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/Betterment/charlatan
 repository: https://github.com/Betterment/charlatan
 

--- a/test/charlatan_http_request_test.dart
+++ b/test/charlatan_http_request_test.dart
@@ -52,10 +52,7 @@ void main() {
         requestOptions: requestOptions,
       );
 
-      expect(subject.headers, {
-        ...headers,
-        'content-type': 'application/json; charset=utf-8',
-      });
+      expect(subject.headers, {...headers});
     });
 
     test('it proxies the query parameters from the request options', () {

--- a/tool/generate_code_coverage.sh
+++ b/tool/generate_code_coverage.sh
@@ -6,4 +6,4 @@ set -o pipefail
 dart pub global activate coverage
 
 # Run tests and generate lcov
-dart test --test-randomize-ordering-seed=random --coverage=coverage && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib
+dart test --coverage=coverage && dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib

--- a/tool/generate_code_coverage.sh
+++ b/tool/generate_code_coverage.sh
@@ -6,4 +6,4 @@ set -o pipefail
 dart pub global activate coverage
 
 # Run tests and generate lcov
-dart test --coverage=coverage && dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
+dart test --test-randomize-ordering-seed=random --coverage=coverage && dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

- Upgrades `dio` dependency to latest major version (`5.0.0`)
- Fixes test that broke as a result of the breaking changes: https://pub.dev/packages/dio/changelog#500

#### Maintenance tasks:
- Fixes `generate_code_coverage` script now that `.packages` spec is no longer a thing
- Upgrades actions versions to remediate underlying deprecations (node runtime, etc.)
- Replaces the `Semantic Pull Requests` Github App with a workflow that uses a Github Action to validate PR titles
