### PR TITLE
feat: add charlatanResponse helper, add type-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+- Add `charlatanResponse` helper to concisely create `CharlatanResponseBuilder` values
+- Remove `statusCode` from `when*` methods
+- Change type of `CharlatanResponseBuilder`
+  from `FutureOr<Object?> Function(CharlatanHttpRequest request, { int statusCode = 200 })`
+  to `FutureOr<CharlatanHttpResponse> Function(CharlatanHttpRequest request)`
+
 ## 0.3.0
 
 - Add `whenMatch` for more complex matching scenarios

--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ configuration method for the HTTP method you want to map a request to.
 
 You can configure fakes responses using a specific path or a URI
 template. You can also use the request object to customize your
-response.
+response. The easiest way to configure a response is with the
+`charlatanResponse` helper function.
 
 ```dart
 final charlatan = Charlatan();
-charlatan.whenPost('/users', (_) => { 'id': 1, 'bilbo' });
-charlatan.whenGet('/users/{id}', (req) => { 'id': req.pathParameters['id'], 'name': 'bilbo' });
-charlatan.whenPut('/users/{id}/profile', (_) => null, statusCode: 204);
-charlatan.whenDelete('/users/{id}', (_) => null, statusCode: 204);
+charlatan.whenPost('/users', charlatanResponse(body: { 'id': 1, 'bilbo' }));
+charlatan.whenGet('/users/{id}', charlatanResponse(body: { 'name': 'bilbo' }));
+charlatan.whenPut('/users/{id}/profile', charlatanResponse(statusCode: 204));
+charlatan.whenDelete('/users/{id}', (req) => CharlatanHttpResponse(statusCode: 204, body: { 'uri': req.path }));
 ```
 
-If you need to further customize the response, you can return a
-`CharlatanHttpResponse`.
+If you need to further customize the response, you can write
+a multiline lambda function that returns a `CharlatanHttpResponse`.
+This allows for dynamic values for the status code, body, and
+headers in the response.
 
 ```dart
 charlatan.whenPost('/users', (req) {
@@ -68,6 +71,16 @@ charlatan.whenPost('/users', (req) {
     body: { 'id': 1, 'name': name },
   );
 });
+```
+
+Additionally, if you need to match requests using other properties of the
+request, you can use `whenMatch`.
+
+```dart
+charlatan.whenMatch(
+  (req) => req.method == 'GET' && req.path.toLowerCase() == '/posts',
+  charlatanResponse(statusCode: 200),
+);
 ```
 
 ### Building a fake HTTP client

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ responses from your [Dio HTTP Client](https://pub.dev/packages/dio).
 This makes it easy to test the behavior of code that interacts with
 HTTP services without having to use mocks.
 
-It consists of two components:
+It consists of a two components and a few helper functions:
 
 - `Charlatan` - a class for configuring and providing fake HTTP responses
   based on HTTP method and URI template.
 - `CharlatanHttpClientAdapter` - an implementation of Dio's
   `HttpClientAdapter` that returns responses from a configured
   `Charlatan` instance.
+- `charlatanResponse` and request matching helpers - utilites for concisely
+  matching HTTP requests and generating fake responses.
 
 ## Usage
 
@@ -46,10 +48,11 @@ charlatan.whenPut('/users/{id}/profile', charlatanResponse(statusCode: 204));
 charlatan.whenDelete('/users/{id}', (req) => CharlatanHttpResponse(statusCode: 204, body: { 'uri': req.path }));
 ```
 
-If you need to further customize the response, you can write
-a multiline lambda function that returns a `CharlatanHttpResponse`.
-This allows for dynamic values for the status code, body, and
-headers in the response.
+If you need to further customize the response, you can expand
+your fake response handler to include whatever you need. The
+only requirement is that it returns a `CharlatanHttpResponse`.
+This allows you to provide dynamic values for the status code,
+body, and headers in the response.
 
 ```dart
 charlatan.whenPost('/users', (req) {
@@ -74,7 +77,7 @@ charlatan.whenPost('/users', (req) {
 ```
 
 Additionally, if you need to match requests using other properties of the
-request, you can use `whenMatch`.
+request or with different logic, you can use `whenMatch`.
 
 ```dart
 charlatan.whenMatch(

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ responses from your [Dio HTTP Client](https://pub.dev/packages/dio).
 This makes it easy to test the behavior of code that interacts with
 HTTP services without having to use mocks.
 
-It consists of a two components and a few helper functions:
+It consists of two components and a few helper functions:
 
 - `Charlatan` - a class for configuring and providing fake HTTP responses
   based on HTTP method and URI template.

--- a/example/main.dart
+++ b/example/main.dart
@@ -13,7 +13,10 @@ void main() {
   });
 
   test('Create a plain fake response', () async {
-    charlatan.whenGet('/user', (_) => {'name': 'frodo'});
+    charlatan.whenGet(
+      '/user',
+      charlatanResponse(statusCode: 200, body: {'name': 'frodo'}),
+    );
 
     final plain = await client.get<Object?>('/user');
     expect(plain.data, {'name': 'frodo'});
@@ -28,22 +31,24 @@ void main() {
         final template = UriTemplate(pathWithTemplate);
         final parser = UriParser(template);
         final pathParameters = parser.parse(uri);
-        return {
-          'id': pathParameters['id'],
-          'name': 'frodo',
-        };
+        return CharlatanHttpResponse(
+          statusCode: 200,
+          body: {
+            'id': pathParameters['id'],
+            'name': 'frodo',
+          },
+        );
       },
     );
 
-    final withPathParams = await client.get<Object?>('/user/12');
+    final withPathParams = await client.get<Object?>('/users/12');
     expect(withPathParams.data, {'id': '12', 'name': 'frodo'});
   });
 
   test('Use a custom status code and an empty body', () async {
     charlatan.whenGet(
       '/posts',
-      (_) => null,
-      statusCode: 204,
+      charlatanResponse(statusCode: 204),
     );
 
     final emptyBody = await client.get<Object?>('/posts');
@@ -54,8 +59,7 @@ void main() {
   test('Use a custom request matcher', () async {
     charlatan.whenMatch(
       (request) => request.method == 'GET' && request.path == '/posts',
-      (_) => null,
-      statusCode: 204,
+      charlatanResponse(statusCode: 204),
     );
 
     final emptyBody = await client.get<Object?>('/posts');
@@ -69,8 +73,7 @@ void main() {
         requestMatchesHttpMethod('GET'),
         requestMatchesPathOrTemplate('/posts'),
       ]),
-      (_) => null,
-      statusCode: 204,
+      charlatanResponse(statusCode: 204),
     );
 
     final emptyBody = await client.get<Object?>('/posts');
@@ -128,13 +131,12 @@ void main() {
         (request) {
           final params = request.body as Map<String, Object?>? ?? {};
           posts.add({'name': params['name']});
-          return null;
+          return CharlatanHttpResponse(statusCode: 204);
         },
-        statusCode: 204,
       )
       ..whenGet(
         '/posts',
-        (_) => {'posts': posts},
+        charlatanResponse(body: {'posts': posts}),
       );
 
     final beforeCreatePost = await client.get<Object?>('/posts');

--- a/lib/charlatan.dart
+++ b/lib/charlatan.dart
@@ -8,6 +8,7 @@ export 'src/charlatan_http_client_adapter.dart';
 export 'src/charlatan_response_definition.dart'
     show
         CharlatanHttpResponse,
+        charlatanResponse,
         requestMatchesAll,
         requestMatchesHttpMethod,
         requestMatchesPathOrTemplate;

--- a/lib/src/charlatan.dart
+++ b/lib/src/charlatan.dart
@@ -29,7 +29,6 @@ class Charlatan {
   void whenMatch(
     CharlatanRequestMatcher requestMatcher,
     CharlatanResponseBuilder responseBuilder, {
-    int statusCode = 200,
     String? description,
   }) {
     _matchers.insert(
@@ -38,7 +37,6 @@ class Charlatan {
         description: description ?? 'Custom Matcher',
         requestMatcher: requestMatcher,
         responseBuilder: responseBuilder,
-        defaultStatusCode: statusCode,
       ),
     );
   }
@@ -48,9 +46,8 @@ class Charlatan {
   /// the [statusCode] will be used.
   void whenGet(
     String pathOrTemplate,
-    CharlatanResponseBuilder responseBuilder, {
-    int statusCode = 200,
-  }) {
+    CharlatanResponseBuilder responseBuilder,
+  ) {
     _matchers.insert(
       0,
       CharlatanResponseDefinition(
@@ -60,7 +57,6 @@ class Charlatan {
           requestMatchesPathOrTemplate(pathOrTemplate),
         ]),
         responseBuilder: responseBuilder,
-        defaultStatusCode: statusCode,
       ),
     );
   }
@@ -70,9 +66,8 @@ class Charlatan {
   /// the [statusCode] will be used.
   void whenPost(
     String pathOrTemplate,
-    CharlatanResponseBuilder responseBuilder, {
-    int statusCode = 200,
-  }) {
+    CharlatanResponseBuilder responseBuilder,
+  ) {
     _matchers.insert(
       0,
       CharlatanResponseDefinition(
@@ -82,7 +77,6 @@ class Charlatan {
           requestMatchesPathOrTemplate(pathOrTemplate),
         ]),
         responseBuilder: responseBuilder,
-        defaultStatusCode: statusCode,
       ),
     );
   }
@@ -92,9 +86,8 @@ class Charlatan {
   /// the [statusCode] will be used.
   void whenPut(
     String pathOrTemplate,
-    CharlatanResponseBuilder responseBuilder, {
-    int statusCode = 200,
-  }) {
+    CharlatanResponseBuilder responseBuilder,
+  ) {
     _matchers.insert(
       0,
       CharlatanResponseDefinition(
@@ -104,7 +97,6 @@ class Charlatan {
           requestMatchesPathOrTemplate(pathOrTemplate),
         ]),
         responseBuilder: responseBuilder,
-        defaultStatusCode: statusCode,
       ),
     );
   }
@@ -114,9 +106,8 @@ class Charlatan {
   /// the [statusCode] will be used.
   void whenDelete(
     String pathOrTemplate,
-    CharlatanResponseBuilder responseBuilder, {
-    int statusCode = 200,
-  }) {
+    CharlatanResponseBuilder responseBuilder,
+  ) {
     _matchers.insert(
       0,
       CharlatanResponseDefinition(
@@ -126,7 +117,6 @@ class Charlatan {
           requestMatchesPathOrTemplate(pathOrTemplate),
         ]),
         responseBuilder: responseBuilder,
-        defaultStatusCode: statusCode,
       ),
     );
   }

--- a/lib/src/charlatan_response_definition.dart
+++ b/lib/src/charlatan_response_definition.dart
@@ -110,7 +110,11 @@ class CharlatanResponseDefinition {
   Future<CharlatanHttpResponse> buildResponse(
     CharlatanHttpRequest request,
   ) async {
-    return responseBuilder(request);
+    final responseOrFuture = responseBuilder(request);
+    if (responseOrFuture is Future<CharlatanHttpResponse>) {
+      return await responseOrFuture;
+    }
+    return responseOrFuture;
   }
 }
 

--- a/lib/src/charlatan_response_definition.dart
+++ b/lib/src/charlatan_response_definition.dart
@@ -16,19 +16,27 @@ typedef CharlatanRequestMatcher = bool Function(
 /// {@template charlatan_response_builder}
 /// A type representing a function to convert an http request into a response.
 ///
-/// The return value may be any json encodable object, a [CharlatanHttpResponse],
-/// or null.
-///
-/// Typically you will want to return a json response of Map<String, Object?>
-/// which will be automatically serialized and returned with a 200 status code.
-///
-/// If you want to customize the headers or the status code of the response, you
-/// can return an instance of [CharlatanHttpResponse].
+/// The return value is a [CharlatanHttpResponse].
 /// {@endtemplate}
-typedef CharlatanResponseBuilder = FutureOr<Object?> Function(
+typedef CharlatanResponseBuilder = FutureOr<CharlatanHttpResponse> Function(
   /// The request including path params, body, headers, options, etc
   CharlatanHttpRequest request,
 );
+
+/// {@template charlatan_response}
+/// A function to build a [CharlatanResponseBuilder]. The [statusCode] defaults
+/// to 200, the [body] defaults to null, and the [headers] defaults to empty.
+/// {@endtemplate}
+CharlatanResponseBuilder charlatanResponse({
+  int statusCode = 200,
+  Object? body,
+  Map<String, String> headers = const {},
+}) =>
+    (request) => CharlatanHttpResponse(
+          statusCode: statusCode,
+          body: body,
+          headers: headers,
+        );
 
 /// {@template charlatan_matches_all}
 /// A function to build a [CharlatanRequestMatcher] that matches if all of the
@@ -84,10 +92,6 @@ class CharlatanResponseDefinition {
   /// The callback that produces the response.
   final CharlatanResponseBuilder responseBuilder;
 
-  /// The default status code to use if the [responseBuilder] does not return.
-  /// a [CharlatanHttpResponse].
-  final int defaultStatusCode;
-
   /// A description of the response definition, e.g. GET /users/123
   final String description;
 
@@ -95,7 +99,6 @@ class CharlatanResponseDefinition {
   CharlatanResponseDefinition({
     required this.requestMatcher,
     required this.responseBuilder,
-    required this.defaultStatusCode,
     required this.description,
   });
 
@@ -107,16 +110,7 @@ class CharlatanResponseDefinition {
   Future<CharlatanHttpResponse> buildResponse(
     CharlatanHttpRequest request,
   ) async {
-    final result = await responseBuilder(request);
-
-    if (result is CharlatanHttpResponse) {
-      return result;
-    }
-
-    return CharlatanHttpResponse(
-      body: result,
-      statusCode: defaultStatusCode,
-    );
+    return responseBuilder(request);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: charlatan
 description: A library for configuring and providing fake HTTP responses to your dio HTTP client.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/Betterment/charlatan
 repository: https://github.com/Betterment/charlatan
 

--- a/test/charlatan_http_client_adapter_test.dart
+++ b/test/charlatan_http_client_adapter_test.dart
@@ -15,14 +15,20 @@ void main() {
     });
 
     test('it matches a url without templated segments', () async {
-      charlatan.whenGet('/user', (request) => {'name': 'frodo'});
+      charlatan.whenGet(
+        '/user',
+        charlatanResponse(statusCode: 200, body: {'name': 'frodo'}),
+      );
 
       final result = await client.get<Object?>('/user');
       expect(result.data, {'name': 'frodo'});
     });
 
     test('it matches a url with templated segments', () async {
-      charlatan.whenGet('/users/{id}', (request) => {'name': 'frodo'});
+      charlatan.whenGet(
+        '/users/{id}',
+        charlatanResponse(statusCode: 200, body: {'name': 'frodo'}),
+      );
 
       final result = await client.get<Object?>('/users/12');
       expect(result.data, {'name': 'frodo'});
@@ -31,8 +37,8 @@ void main() {
     test('it matches the longest matching url with templated segments',
         () async {
       charlatan
-        ..whenGet('/users/{id}', (request) => {'name': 'frodo'})
-        ..whenGet('/users/{id}/profile', (request) => {'age': 12});
+        ..whenGet('/users/{id}', charlatanResponse(body: {'name': 'frodo'}))
+        ..whenGet('/users/{id}/profile', charlatanResponse(body: {'age': 12}));
 
       final result = await client.get<Object?>('/users/12/profile');
       expect(result.data, {'age': 12});
@@ -40,10 +46,10 @@ void main() {
 
     test('it disambiguates matches by http method', () async {
       charlatan
-        ..whenGet('/users', (request) => {'name': 'frodo'})
-        ..whenPost('/users', (request) => {'name': 'sam'})
-        ..whenPut('/users', (request) => {'name': 'gandalf'})
-        ..whenDelete('/users', (request) => {'name': 'bilbo'});
+        ..whenGet('/users', charlatanResponse(body: {'name': 'frodo'}))
+        ..whenPost('/users', charlatanResponse(body: {'name': 'sam'}))
+        ..whenPut('/users', charlatanResponse(body: {'name': 'gandalf'}))
+        ..whenDelete('/users', charlatanResponse(body: {'name': 'bilbo'}));
 
       final getResult = await client.get<Object?>('/users');
       expect(getResult.data, {'name': 'frodo'});
@@ -61,8 +67,8 @@ void main() {
     test('it overrides existing definitions for the same method and url',
         () async {
       charlatan
-        ..whenGet('/users', (request) => {'name': 'frodo'}) //
-        ..whenGet('/users', (request) => {'name': 'bilbo'});
+        ..whenGet('/users', charlatanResponse(body: {'name': 'frodo'})) //
+        ..whenGet('/users', charlatanResponse(body: {'name': 'bilbo'}));
 
       final getResult = await client.get<Object?>('/users');
       expect(getResult.data, {'name': 'bilbo'});
@@ -70,10 +76,10 @@ void main() {
 
     test('it returns a helpful error message when no match is found', () async {
       charlatan
-        ..whenGet('/users', (request) => {'name': 'frodo'})
-        ..whenPost('/users', (request) => {'name': 'sam'})
-        ..whenPut('/users', (request) => {'name': 'gandalf'})
-        ..whenDelete('/users', (request) => {'name': 'bilbo'});
+        ..whenGet('/users', charlatanResponse(body: {'name': 'frodo'}))
+        ..whenPost('/users', charlatanResponse(body: {'name': 'sam'}))
+        ..whenPut('/users', charlatanResponse(body: {'name': 'gandalf'}))
+        ..whenDelete('/users', charlatanResponse(body: {'name': 'bilbo'}));
 
       expect(
         () async => client.get<Object?>('/blahhhh'),
@@ -100,14 +106,15 @@ DELETE /users
     });
 
     test('it supports query strings', () async {
-      charlatan.whenGet('/users{?foo}', (request) => {'name': 'frodo'});
+      charlatan.whenGet(
+          '/users{?foo}', charlatanResponse(body: {'name': 'frodo'}));
 
       final result = await client.get<Object?>('/users?foo=bar');
       expect(result.data, {'name': 'frodo'});
     });
 
     test('it supports bytes response bodies', () async {
-      charlatan.whenGet('/user.png', (request) => Uint8List(1));
+      charlatan.whenGet('/user.png', charlatanResponse(body: Uint8List(1)));
 
       final result = await client.get<Object?>(
         '/user.png',
@@ -119,7 +126,8 @@ DELETE /users
     test('it supports async response body builders', () async {
       charlatan.whenGet(
         '/user',
-        (_) async => Future.delayed(Duration.zero, () => {'name': 'frodo'}),
+        (_) async => Future.delayed(Duration.zero,
+            () => CharlatanHttpResponse(body: {'name': 'frodo'})),
       );
 
       final result = await client.get<Object?>('/user');
@@ -151,7 +159,7 @@ DELETE /users
       test('it returns a 200 status by default', () async {
         charlatan.whenMatch(
           (request) => request.path == '/user',
-          (request) => null,
+          charlatanResponse(),
         );
 
         final result = await client.get<Object?>('/user');
@@ -161,8 +169,7 @@ DELETE /users
       test('it returns the provided status', () async {
         charlatan.whenMatch(
           (request) => request.path == '/user',
-          (request) => null,
-          statusCode: 404,
+          charlatanResponse(statusCode: 404),
         );
 
         expect(
@@ -180,14 +187,14 @@ DELETE /users
 
     group('whenGet', () {
       test('it returns a 200 status by default', () async {
-        charlatan.whenGet('/user', (request) => null);
+        charlatan.whenGet('/user', charlatanResponse());
 
         final result = await client.get<Object?>('/user');
         expect(result.statusCode, 200);
       });
 
       test('it returns the provided status', () async {
-        charlatan.whenGet('/user', (request) => null, statusCode: 404);
+        charlatan.whenGet('/user', charlatanResponse(statusCode: 404));
 
         expect(
           client.get<Object?>('/user'),
@@ -204,14 +211,14 @@ DELETE /users
 
     group('whenPost', () {
       test('it returns a 200 status by default', () async {
-        charlatan.whenPost('/user', (request) => null);
+        charlatan.whenPost('/user', charlatanResponse());
 
         final result = await client.post<Object?>('/user');
         expect(result.statusCode, 200);
       });
 
       test('it returns the provided status', () async {
-        charlatan.whenPost('/user', (request) => null, statusCode: 404);
+        charlatan.whenPost('/user', charlatanResponse(statusCode: 404));
 
         expect(
           client.post<Object?>('/user'),
@@ -228,14 +235,14 @@ DELETE /users
 
     group('whenPut', () {
       test('it returns a 200 status by default', () async {
-        charlatan.whenPut('/user', (request) => null);
+        charlatan.whenPut('/user', charlatanResponse());
 
         final result = await client.put<Object?>('/user');
         expect(result.statusCode, 200);
       });
 
       test('it returns the provided status', () async {
-        charlatan.whenPut('/user', (request) => null, statusCode: 404);
+        charlatan.whenPut('/user', charlatanResponse(statusCode: 404));
 
         expect(
           client.put<Object?>('/user'),
@@ -252,14 +259,14 @@ DELETE /users
 
     group('whenDelete', () {
       test('it returns a 200 status by default', () async {
-        charlatan.whenDelete('/user', (request) => null);
+        charlatan.whenDelete('/user', charlatanResponse());
 
         final result = await client.delete<Object?>('/user');
         expect(result.statusCode, 200);
       });
 
       test('it returns the provided status', () async {
-        charlatan.whenDelete('/user', (request) => null, statusCode: 404);
+        charlatan.whenDelete('/user', charlatanResponse(statusCode: 404));
 
         expect(
           client.delete<Object?>('/user'),


### PR DESCRIPTION
fixes #24

this changeset adds a new `charlatanResponse` helper function that returns a `CharlatanResponseBuilder` with a default status code.

this new helper function replaces the previous approach of returning an `Object?` from the `CharlatanResponseBuilder` type. This makes it safer to work with in your codebase but is a breaking change.

To migrate to this version, replace any usages of directly returning anything other than `CharlatanHttpResponse` in `when*` methods with a a call to `charlatanResponse` or an explicit `CharlatanHttpResponse` instance.

### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR
