### PR TITLE
chore: set git identity prior to creating tag (NOBUMP)

### DIFF
--- a/.github/workflows/tag_and_create_release.yaml
+++ b/.github/workflows/tag_and_create_release.yaml
@@ -47,6 +47,8 @@ jobs:
       - name: Create tag
         if: ${{ steps.should-release.outputs.should-release }}
         run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
           git tag -fa ${{ steps.should-release.outputs.curr-version }} -m "release ${{ steps.should-release.outputs.curr-version }}"
           git push -f --tags
       - name: Create release

--- a/.github/workflows/tag_and_create_release.yaml
+++ b/.github/workflows/tag_and_create_release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   tag_and_create_draft_release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pusher.name == 'betterment-mobile-cicd[bot]' }}
+    if: ${{ github.event.pusher.name == 'betterment-mobile-cicd[bot]' }} || ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/tag_and_create_release.yaml
+++ b/.github/workflows/tag_and_create_release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: [CHANGELOG.md, pubspec.yaml]
+  workflow_dispatch:
 
 jobs:
   tag_and_create_draft_release:


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

Adds identity setting before attempting to create a tag.
