### PR TITLE
chore: Pin Github Actions to Commit Hashes (NOBUMP)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
       - name: Get application token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# ignore: RiskyTriggers
 on:
   workflow_dispatch:
 
@@ -11,15 +12,18 @@ jobs:
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
+
       - name: Get application token
         id: get_token
         uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
         with:
           application_id: ${{ secrets.CI_APP_ID }}
           application_private_key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - name: Get version
         id: version
         uses: paulhatch/semantic-version@ea50fff3e41d24bb283f22b7343c4b3a314282fb #v5.0.2
+
       - name: Get Latest Release
         id: latest-release
         uses: pozetroninc/github-action-get-latest-release@d1dafdb6e338bdab109e6afce581a01858680dfb # v0.7.0
@@ -28,6 +32,7 @@ jobs:
           repo: charlatan
           excludes: prerelease, draft
           token: ${{ github.token }}
+
       - name: Generate release notes
         id: release-notes
         uses: mikepenz/release-changelog-builder-action@3a70419f3cc01ac7458a4fa44f09726475edfc6a # v3.4.0
@@ -37,29 +42,35 @@ jobs:
           configuration: .github/workflows/release_changelog_configuration.json
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
       - name: Setup dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
+
       - name: Setup cider
         run: dart pub global activate cider
+
       - name: Update CHANGELOG and pubspec.yaml
         run: |
-          cider version ${{ steps.version.outputs.version }}
+          cider version "${{ steps.version.outputs.version }}"
           cat <(echo -e "## ${{ steps.version.outputs.version }} - $(date +%Y-%m-%d) \n\n${{ steps.release-notes.outputs.changelog }}\n\n") CHANGELOG.md > NEW_CHANGELOG.md
           mv NEW_CHANGELOG.md CHANGELOG.md
           git add CHANGELOG.md pubspec.yaml
+
       - name: Create pull request
         id: create_pull_request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           token: ${{ steps.get_token.outputs.token }}
-          branch: 'bot/prep-release-${{ steps.version.outputs.version }}'
-          title: 'chore(release): update CHANGELOG and pubspec.yaml for version `${{ steps.version.outputs.version }}` (NOBUMP)'
-          commit-message: 'chore(release): update CHANGELOG and pubspec.yaml for version `${{ steps.version.outputs.version }}`'
+          branch: "bot/prep-release-${{ steps.version.outputs.version }}"
+          title: "chore(release): update CHANGELOG and pubspec.yaml for version `${{ steps.version.outputs.version }}` (NOBUMP)"
+          commit-message: "chore(release): update CHANGELOG and pubspec.yaml for version `${{ steps.version.outputs.version }}`"
           add-paths: |
             CHANGELOG.md
             pubspec.yaml
           base: main
+
       - name: Merge pull request
-        run: gh pr merge ${{ steps.create_pull_request.outputs.pull-request-number }} --squash --auto --delete-branch
+        # ignore: AutomaticMerge
+        run: gh pr merge "${{ steps.create_pull_request.outputs.pull-request-number }}" --squash --auto --delete-branch
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
This PR includes automated changes from running [frizbee](https://github.com/stacklok/frizbee) to pin Github Actions. For more information on what this actually means, take a look at [our documentation on UnpinnedActions](https://github.com/betterment/claws?tab=readme-ov-file#unpinnedactions). Because `frizbee` will be replacing tags with their corresponding commit hash, this change should fundamentally be a no-op. This change just makes our code more explicit about what we're using.

Note that because we're touching Github Workflow files in this PR, there is a chance that [Claws](https://github.com/betterment/claws), our GHA Static Analyzer, will find other issues in those files that were introduced before this PR was created. These findings will need to be addressed before this PR can be merged. 

The Claws documentation has a good list for how to remediate each type of finding, but for brevity, here are some of the commonly seen ones:

* RiskyTriggers: Fires when a workflow has workflow_dispatch or pull_request_target; remediate by leaving comments explaning why, and put an ignore statement ([example](https://github.com/Betterment/retail/blob/92e76923f4e5d51e8386301538e383883cd5eb57/.github/workflows/create_datadog_slo.yml#L2-L4))
* UnsafeCheckout: Fires when a workflow checks out user supplied code; remediate by leaving a comment explaining how the user supplied code is used and confirm it isn't executed ([example](https://github.com/Betterment/linda-test/blob/6cd5954c7c1d2bdb781239b6686b3a5dcbcd6fda/.github/workflows/claws_fork_friendly.yml#L50-L54))

For other findings and how to remediate them, check the [Claws docs!](https://github.com/betterment/claws?tab=readme-ov-file#built-in-rules)

